### PR TITLE
refactor: Migrate context logging from zap to slog and deprecate OTEL metrics setup

### DIFF
--- a/contextx/contextx_test.go
+++ b/contextx/contextx_test.go
@@ -3,6 +3,7 @@ package contextx
 import (
 	"context"
 	"log/slog"
+	"os"
 	"testing"
 )
 
@@ -10,6 +11,23 @@ func TestWithContext(t *testing.T) {
 	slog.SetLogLoggerLevel(slog.LevelDebug)
 
 	c := context.Background()
+	ctx := WithContext(c)
+
+	ctx.Debug("debug message")
+	ctx.Info("info message")
+	ctx.Warn("warn message")
+	ctx.Error("error message")
+}
+
+func TestWithLogger(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		AddSource:   true,
+		Level:       slog.LevelDebug,
+		ReplaceAttr: nil,
+	}))
+
+	c := context.Background()
+	c = WithLogger(c, logger)
 	ctx := WithContext(c)
 
 	ctx.Debug("debug message")

--- a/contextx/contextx_test.go
+++ b/contextx/contextx_test.go
@@ -2,23 +2,17 @@ package contextx
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 )
 
 func TestWithContext(t *testing.T) {
+	slog.SetLogLoggerLevel(slog.LevelDebug)
+
 	c := context.Background()
 	ctx := WithContext(c)
 
-	ctx.Info("info message")
-	ctx.Warn("warn message")
-	ctx.Error("error message")
-}
-
-func TestSpanFromContext(t *testing.T) {
-	c := context.Background()
-	ctx, span := SpanFromContext(c, "span name")
-	defer span.End()
-
+	ctx.Debug("debug message")
 	ctx.Info("info message")
 	ctx.Warn("warn message")
 	ctx.Error("error message")

--- a/metrics/otelx.go
+++ b/metrics/otelx.go
@@ -1,147 +1,148 @@
 package metrics
 
-import (
-	"context"
-	"fmt"
-	"time"
-
-	"github.com/blackhorseya/go-libs/contextx"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
-	"go.opentelemetry.io/otel/propagation"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
-	"go.uber.org/zap"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-)
-
-// SDK is the OpenTelemetry SDK.
-type SDK struct {
-	target      string
-	serviceName string
-}
-
-// SetupSDK creates a new OpenTelemetry SDK.
-func SetupSDK(target string, name string) (*SDK, func(), error) {
-	ctx := contextx.WithContext(context.Background())
-
-	instance := &SDK{
-		target:      target,
-		serviceName: name,
-	}
-
-	clean, err := instance.setupOTelSDK(ctx)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to setup OpenTelemetry SDK: %w", err)
-	}
-
-	return instance, clean, nil
-}
-
-func (x *SDK) setupOTelSDK(ctx contextx.Contextx) (func(), error) {
-	if x.target == "" {
-		ctx.Warn("OpenTelemetry is disabled")
-		return func() {
-			ctx.Debug("noop")
-		}, nil
-	}
-
-	ctx.Info(
-		"setting up OpenTelemetry SDK",
-		zap.String("service_name", x.serviceName),
-		zap.String("otlp", x.target),
-	)
-
-	var shutdownFuncs []func(context.Context) error
-
-	res, err := resource.New(ctx, resource.WithAttributes(semconv.ServiceNameKey.String(x.serviceName)))
-	if err != nil {
-		ctx.Error("failed to create resource", zap.Error(err))
-		return nil, err
-	}
-
-	conn, err := initConn(x.target)
-	if err != nil {
-		ctx.Error("failed to create gRPC client", zap.Error(err))
-		return nil, err
-	}
-
-	tracerProvider, err := newTracer(ctx, res, conn)
-	if err != nil {
-		ctx.Error("failed to create the Jaeger exporter", zap.Error(err))
-		return nil, err
-	}
-	shutdownFuncs = append(shutdownFuncs, tracerProvider.Shutdown)
-
-	meterProvider, err := newMeter(ctx, res, conn)
-	if err != nil {
-		ctx.Error("failed to create the OTLP exporter", zap.Error(err))
-		return nil, err
-	}
-	shutdownFuncs = append(shutdownFuncs, meterProvider.Shutdown)
-
-	return func() {
-		ctx.Info("shutting down OpenTelemetry SDK")
-		for _, fn := range shutdownFuncs {
-			_ = fn(ctx)
-		}
-	}, nil
-}
-
-func initConn(target string) (*grpc.ClientConn, error) {
-	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create gRPC client: %w", err)
-	}
-
-	return conn, nil
-}
-
-func newTracer(
-	ctx context.Context,
-	res *resource.Resource,
-	conn *grpc.ClientConn,
-) (*sdktrace.TracerProvider, error) {
-	exporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithGRPCConn(conn))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create the Jaeger exporter: %w", err)
-	}
-
-	processor := sdktrace.NewBatchSpanProcessor(exporter)
-	provider := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		sdktrace.WithResource(res),
-		sdktrace.WithSpanProcessor(processor),
-	)
-	otel.SetTracerProvider(provider)
-
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-		propagation.TraceContext{},
-		propagation.Baggage{},
-	))
-
-	return provider, nil
-}
-
-func newMeter(
-	ctx context.Context,
-	res *resource.Resource,
-	conn *grpc.ClientConn,
-) (p *sdkmetric.MeterProvider, err error) {
-	exporter, err := otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithGRPCConn(conn))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create the OTLP exporter: %w", err)
-	}
-
-	provider := sdkmetric.NewMeterProvider(
-		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(3*time.Second))),
-		sdkmetric.WithResource(res),
-	)
-	otel.SetMeterProvider(provider)
-
-	return provider, nil
-}
+//
+// import (
+// 	"context"
+// 	"fmt"
+// 	"time"
+//
+// 	"github.com/blackhorseya/go-libs/contextx"
+// 	"go.opentelemetry.io/otel"
+// 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+// 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+// 	"go.opentelemetry.io/otel/propagation"
+// 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+// 	"go.opentelemetry.io/otel/sdk/resource"
+// 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+// 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+// 	"go.uber.org/zap"
+// 	"google.golang.org/grpc"
+// 	"google.golang.org/grpc/credentials/insecure"
+// )
+//
+// // SDK is the OpenTelemetry SDK.
+// type SDK struct {
+// 	target      string
+// 	serviceName string
+// }
+//
+// // SetupSDK creates a new OpenTelemetry SDK.
+// func SetupSDK(target string, name string) (*SDK, func(), error) {
+// 	ctx := contextx.WithContext(context.Background())
+//
+// 	instance := &SDK{
+// 		target:      target,
+// 		serviceName: name,
+// 	}
+//
+// 	clean, err := instance.setupOTelSDK(ctx)
+// 	if err != nil {
+// 		return nil, nil, fmt.Errorf("failed to setup OpenTelemetry SDK: %w", err)
+// 	}
+//
+// 	return instance, clean, nil
+// }
+//
+// func (x *SDK) setupOTelSDK(ctx contextx.Contextx) (func(), error) {
+// 	if x.target == "" {
+// 		ctx.Warn("OpenTelemetry is disabled")
+// 		return func() {
+// 			ctx.Debug("noop")
+// 		}, nil
+// 	}
+//
+// 	ctx.Info(
+// 		"setting up OpenTelemetry SDK",
+// 		zap.String("service_name", x.serviceName),
+// 		zap.String("otlp", x.target),
+// 	)
+//
+// 	var shutdownFuncs []func(context.Context) error
+//
+// 	res, err := resource.New(ctx, resource.WithAttributes(semconv.ServiceNameKey.String(x.serviceName)))
+// 	if err != nil {
+// 		ctx.Error("failed to create resource", zap.Error(err))
+// 		return nil, err
+// 	}
+//
+// 	conn, err := initConn(x.target)
+// 	if err != nil {
+// 		ctx.Error("failed to create gRPC client", zap.Error(err))
+// 		return nil, err
+// 	}
+//
+// 	tracerProvider, err := newTracer(ctx, res, conn)
+// 	if err != nil {
+// 		ctx.Error("failed to create the Jaeger exporter", zap.Error(err))
+// 		return nil, err
+// 	}
+// 	shutdownFuncs = append(shutdownFuncs, tracerProvider.Shutdown)
+//
+// 	meterProvider, err := newMeter(ctx, res, conn)
+// 	if err != nil {
+// 		ctx.Error("failed to create the OTLP exporter", zap.Error(err))
+// 		return nil, err
+// 	}
+// 	shutdownFuncs = append(shutdownFuncs, meterProvider.Shutdown)
+//
+// 	return func() {
+// 		ctx.Info("shutting down OpenTelemetry SDK")
+// 		for _, fn := range shutdownFuncs {
+// 			_ = fn(ctx)
+// 		}
+// 	}, nil
+// }
+//
+// func initConn(target string) (*grpc.ClientConn, error) {
+// 	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to create gRPC client: %w", err)
+// 	}
+//
+// 	return conn, nil
+// }
+//
+// func newTracer(
+// 	ctx context.Context,
+// 	res *resource.Resource,
+// 	conn *grpc.ClientConn,
+// ) (*sdktrace.TracerProvider, error) {
+// 	exporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithGRPCConn(conn))
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to create the Jaeger exporter: %w", err)
+// 	}
+//
+// 	processor := sdktrace.NewBatchSpanProcessor(exporter)
+// 	provider := sdktrace.NewTracerProvider(
+// 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+// 		sdktrace.WithResource(res),
+// 		sdktrace.WithSpanProcessor(processor),
+// 	)
+// 	otel.SetTracerProvider(provider)
+//
+// 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+// 		propagation.TraceContext{},
+// 		propagation.Baggage{},
+// 	))
+//
+// 	return provider, nil
+// }
+//
+// func newMeter(
+// 	ctx context.Context,
+// 	res *resource.Resource,
+// 	conn *grpc.ClientConn,
+// ) (p *sdkmetric.MeterProvider, err error) {
+// 	exporter, err := otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithGRPCConn(conn))
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to create the OTLP exporter: %w", err)
+// 	}
+//
+// 	provider := sdkmetric.NewMeterProvider(
+// 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(3*time.Second))),
+// 		sdkmetric.WithResource(res),
+// 	)
+// 	otel.SetMeterProvider(provider)
+//
+// 	return provider, nil
+// }


### PR DESCRIPTION
### **User description**
This pull request includes significant changes to the `contextx` package, focusing on replacing the logging framework and removing OpenTelemetry integration. The most important changes include switching from `zap` to `slog`, adding new context-related functions, and removing OpenTelemetry setup and related code.

### Logging framework replacement:

* [`contextx/contextx.go`](diffhunk://#diff-e3b0c143ea81654a53ce3f7c25c53e0101aadeaeb106155bfe0f4a2079ba6ae9L5-R41): Replaced `zap` with `slog` for logging. Introduced new functions `WithLogger` and `GetLogger` to manage loggers within context.
* [`contextx/contextx_test.go`](diffhunk://#diff-ec3e15867a3b0bb2c4fc6033d1389c11583b17be2ddf0d6665c8e35cc162275cR5-R33): Updated tests to use `slog` for logging and added a new test for the `WithLogger` function.

### OpenTelemetry removal:

* [`metrics/otelx.go`](diffhunk://#diff-283adbebe414300cd0b3cdd991dbc374b3ad3e3a6a97bf21c710a2b4b50340f2L3-R148): Removed the entire OpenTelemetry setup and related code, including functions for setting up the SDK, initializing connections, and creating tracers and meters.


___

### **PR Type**
- Enhancement
- Tests



___

### **Description**
- Switch logging from zap to slog library

- Introduce WithLogger and GetLogger functions for context logging

- Update tests to use new slog-based logger

- Deprecate and comment out OpenTelemetry metrics integration


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contextx.go</strong><dd><code>Refactor context logging to use slog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contextx/contextx.go

<li>Removed zap and otel imports, added slog instead<br> <li> Added loggerKey type and default logger retrieval functions<br> <li> Updated WithContext to use GetLogger for context propagation<br> <li> Deprecated SpanFromContext and introduced WithLogger function


</details>


  </td>
  <td><a href="https://github.com/blackhorseya/go-libs/pull/4/files#diff-e3b0c143ea81654a53ce3f7c25c53e0101aadeaeb106155bfe0f4a2079ba6ae9">+24/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>otelx.go</strong><dd><code>Deprecate OpenTelemetry metrics setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

metrics/otelx.go

<li>Commented out entire OpenTelemetry SDK setup code block<br> <li> Removed initialization of otel and zap dependencies in metrics<br> <li> Left commented code for future reference/deprecation notice


</details>


  </td>
  <td><a href="https://github.com/blackhorseya/go-libs/pull/4/files#diff-283adbebe414300cd0b3cdd991dbc374b3ad3e3a6a97bf21c710a2b4b50340f2">+146/-145</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contextx_test.go</strong><dd><code>Update tests for slog-based logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contextx/contextx_test.go

<li>Updated tests to use slog by setting debug level<br> <li> Added TestWithLogger for new logging functions<br> <li> Removed SpanFromContext test


</details>


  </td>
  <td><a href="https://github.com/blackhorseya/go-libs/pull/4/files#diff-ec3e15867a3b0bb2c4fc6033d1389c11583b17be2ddf0d6665c8e35cc162275c">+15/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>