### PR TITLE
refactor: refactor OpenTelemetry setup and clean up imports

### DIFF
--- a/metrics/otelx.go
+++ b/metrics/otelx.go
@@ -1,148 +1,146 @@
 package metrics
 
-//
-// import (
-// 	"context"
-// 	"fmt"
-// 	"time"
-//
-// 	"github.com/blackhorseya/go-libs/contextx"
-// 	"go.opentelemetry.io/otel"
-// 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
-// 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
-// 	"go.opentelemetry.io/otel/propagation"
-// 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-// 	"go.opentelemetry.io/otel/sdk/resource"
-// 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-// 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
-// 	"go.uber.org/zap"
-// 	"google.golang.org/grpc"
-// 	"google.golang.org/grpc/credentials/insecure"
-// )
-//
-// // SDK is the OpenTelemetry SDK.
-// type SDK struct {
-// 	target      string
-// 	serviceName string
-// }
-//
-// // SetupSDK creates a new OpenTelemetry SDK.
-// func SetupSDK(target string, name string) (*SDK, func(), error) {
-// 	ctx := contextx.WithContext(context.Background())
-//
-// 	instance := &SDK{
-// 		target:      target,
-// 		serviceName: name,
-// 	}
-//
-// 	clean, err := instance.setupOTelSDK(ctx)
-// 	if err != nil {
-// 		return nil, nil, fmt.Errorf("failed to setup OpenTelemetry SDK: %w", err)
-// 	}
-//
-// 	return instance, clean, nil
-// }
-//
-// func (x *SDK) setupOTelSDK(ctx contextx.Contextx) (func(), error) {
-// 	if x.target == "" {
-// 		ctx.Warn("OpenTelemetry is disabled")
-// 		return func() {
-// 			ctx.Debug("noop")
-// 		}, nil
-// 	}
-//
-// 	ctx.Info(
-// 		"setting up OpenTelemetry SDK",
-// 		zap.String("service_name", x.serviceName),
-// 		zap.String("otlp", x.target),
-// 	)
-//
-// 	var shutdownFuncs []func(context.Context) error
-//
-// 	res, err := resource.New(ctx, resource.WithAttributes(semconv.ServiceNameKey.String(x.serviceName)))
-// 	if err != nil {
-// 		ctx.Error("failed to create resource", zap.Error(err))
-// 		return nil, err
-// 	}
-//
-// 	conn, err := initConn(x.target)
-// 	if err != nil {
-// 		ctx.Error("failed to create gRPC client", zap.Error(err))
-// 		return nil, err
-// 	}
-//
-// 	tracerProvider, err := newTracer(ctx, res, conn)
-// 	if err != nil {
-// 		ctx.Error("failed to create the Jaeger exporter", zap.Error(err))
-// 		return nil, err
-// 	}
-// 	shutdownFuncs = append(shutdownFuncs, tracerProvider.Shutdown)
-//
-// 	meterProvider, err := newMeter(ctx, res, conn)
-// 	if err != nil {
-// 		ctx.Error("failed to create the OTLP exporter", zap.Error(err))
-// 		return nil, err
-// 	}
-// 	shutdownFuncs = append(shutdownFuncs, meterProvider.Shutdown)
-//
-// 	return func() {
-// 		ctx.Info("shutting down OpenTelemetry SDK")
-// 		for _, fn := range shutdownFuncs {
-// 			_ = fn(ctx)
-// 		}
-// 	}, nil
-// }
-//
-// func initConn(target string) (*grpc.ClientConn, error) {
-// 	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
-// 	if err != nil {
-// 		return nil, fmt.Errorf("failed to create gRPC client: %w", err)
-// 	}
-//
-// 	return conn, nil
-// }
-//
-// func newTracer(
-// 	ctx context.Context,
-// 	res *resource.Resource,
-// 	conn *grpc.ClientConn,
-// ) (*sdktrace.TracerProvider, error) {
-// 	exporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithGRPCConn(conn))
-// 	if err != nil {
-// 		return nil, fmt.Errorf("failed to create the Jaeger exporter: %w", err)
-// 	}
-//
-// 	processor := sdktrace.NewBatchSpanProcessor(exporter)
-// 	provider := sdktrace.NewTracerProvider(
-// 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-// 		sdktrace.WithResource(res),
-// 		sdktrace.WithSpanProcessor(processor),
-// 	)
-// 	otel.SetTracerProvider(provider)
-//
-// 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-// 		propagation.TraceContext{},
-// 		propagation.Baggage{},
-// 	))
-//
-// 	return provider, nil
-// }
-//
-// func newMeter(
-// 	ctx context.Context,
-// 	res *resource.Resource,
-// 	conn *grpc.ClientConn,
-// ) (p *sdkmetric.MeterProvider, err error) {
-// 	exporter, err := otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithGRPCConn(conn))
-// 	if err != nil {
-// 		return nil, fmt.Errorf("failed to create the OTLP exporter: %w", err)
-// 	}
-//
-// 	provider := sdkmetric.NewMeterProvider(
-// 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(3*time.Second))),
-// 		sdkmetric.WithResource(res),
-// 	)
-// 	otel.SetMeterProvider(provider)
-//
-// 	return provider, nil
-// }
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/blackhorseya/go-libs/contextx"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// SDK is the OpenTelemetry SDK.
+type SDK struct {
+	target      string
+	serviceName string
+}
+
+// SetupSDK creates a new OpenTelemetry SDK.
+func SetupSDK(target string, name string) (*SDK, func(), error) {
+	ctx := contextx.WithContext(context.Background())
+
+	instance := &SDK{
+		target:      target,
+		serviceName: name,
+	}
+
+	clean, err := instance.setupOTelSDK(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to setup OpenTelemetry SDK: %w", err)
+	}
+
+	return instance, clean, nil
+}
+
+func (x *SDK) setupOTelSDK(ctx contextx.Contextx) (func(), error) {
+	if x.target == "" {
+		ctx.Warn("OpenTelemetry is disabled")
+		return func() {
+			ctx.Debug("noop")
+		}, nil
+	}
+
+	ctx.Info(
+		"setting up OpenTelemetry SDK",
+		"service_name", x.serviceName,
+		"otlp", x.target,
+	)
+
+	var shutdownFuncs []func(context.Context) error
+
+	res, err := resource.New(ctx, resource.WithAttributes(semconv.ServiceNameKey.String(x.serviceName)))
+	if err != nil {
+		ctx.Error("failed to create resource", "error", err)
+		return nil, err
+	}
+
+	conn, err := initConn(x.target)
+	if err != nil {
+		ctx.Error("failed to create gRPC client", "error", err)
+		return nil, err
+	}
+
+	tracerProvider, err := newTracer(ctx, res, conn)
+	if err != nil {
+		ctx.Error("failed to create the Jaeger exporter", "error", err)
+		return nil, err
+	}
+	shutdownFuncs = append(shutdownFuncs, tracerProvider.Shutdown)
+
+	meterProvider, err := newMeter(ctx, res, conn)
+	if err != nil {
+		ctx.Error("failed to create the OTLP exporter", "error", err)
+		return nil, err
+	}
+	shutdownFuncs = append(shutdownFuncs, meterProvider.Shutdown)
+
+	return func() {
+		ctx.Info("shutting down OpenTelemetry SDK")
+		for _, fn := range shutdownFuncs {
+			_ = fn(ctx)
+		}
+	}, nil
+}
+
+func initConn(target string) (*grpc.ClientConn, error) {
+	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gRPC client: %w", err)
+	}
+
+	return conn, nil
+}
+
+func newTracer(
+	c context.Context,
+	res *resource.Resource,
+	conn *grpc.ClientConn,
+) (*sdktrace.TracerProvider, error) {
+	exporter, err := otlptracegrpc.New(c, otlptracegrpc.WithGRPCConn(conn))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the Jaeger exporter: %w", err)
+	}
+
+	processor := sdktrace.NewBatchSpanProcessor(exporter)
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithResource(res),
+		sdktrace.WithSpanProcessor(processor),
+	)
+	otel.SetTracerProvider(provider)
+
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	return provider, nil
+}
+
+func newMeter(
+	ctx context.Context,
+	res *resource.Resource,
+	conn *grpc.ClientConn,
+) (p *sdkmetric.MeterProvider, err error) {
+	exporter, err := otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithGRPCConn(conn))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the OTLP exporter: %w", err)
+	}
+
+	provider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(3*time.Second))),
+		sdkmetric.WithResource(res),
+	)
+	otel.SetMeterProvider(provider)
+
+	return provider, nil
+}


### PR DESCRIPTION
### **User description**
This pull request includes changes to reintroduce the previously commented-out OpenTelemetry SDK setup in the `metrics/otelx.go` file. The reintroduction involves adding back the necessary imports, type definitions, and functions to set up the OpenTelemetry SDK for tracing and metrics.

Key changes include:

* Reintroduced the import statements for OpenTelemetry and related packages, which are necessary for setting up the SDK. (`metrics/otelx.go`)
* Reintroduced the `SDK` struct definition, which holds the target and service name for the OpenTelemetry setup. (`metrics/otelx.go`)
* Reintroduced the `SetupSDK` function, which initializes the OpenTelemetry SDK and returns a cleanup function. (`metrics/otelx.go`)
* Reintroduced the `setupOTelSDK` method, which configures the OpenTelemetry SDK, including setting up the tracer and meter providers. (`metrics/otelx.go`)
* Reintroduced the helper functions `initConn`, `newTracer`, and `newMeter`, which are used to initialize the gRPC connection and create the tracer and meter providers. (`metrics/otelx.go`)


___

### **PR Type**
- Enhancement



___

### **Description**
- Removed legacy commented-out code.

- Re-enabled active OpenTelemetry SDK setup.

- Simplified import declarations and logging.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>otelx.go</strong><dd><code>Simplify and activate OpenTelemetry SDK setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

metrics/otelx.go

<li>Removed commented-out code block.<br> <li> Reintroduced active import statements.<br> <li> Re-enabled SDK struct, SetupSDK function, and associated functions.<br> <li> Updated logging format with key-value pairs.


</details>


  </td>
  <td><a href="https://github.com/blackhorseya/go-libs/pull/5/files#diff-283adbebe414300cd0b3cdd991dbc374b3ad3e3a6a97bf21c710a2b4b50340f2">+144/-146</a></td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>