### PR TITLE
feat: Add configurable HTTP server with options pattern

### DIFF
--- a/httpx/options.go
+++ b/httpx/options.go
@@ -1,15 +1,18 @@
 package httpx
 
 import (
+	"log/slog"
 	"time"
 )
 
-// ServerOption is a function that configures the server
+// ServerOption defines a function type for configuring server options.
 type ServerOption func(opts *serverOptions)
 
+// serverOptions holds configuration options for starting and shutting down the server.
 type serverOptions struct {
 	Host            string
 	Port            int
+	Logger          *slog.Logger
 	ShutdownTimeout time.Duration
 }
 
@@ -24,6 +27,13 @@ func WithHost(host string) ServerOption {
 func WithPort(port int) ServerOption {
 	return func(opts *serverOptions) {
 		opts.Port = port
+	}
+}
+
+// WithLogger sets the logger of the server
+func WithLogger(logger *slog.Logger) ServerOption {
+	return func(opts *serverOptions) {
+		opts.Logger = logger
 	}
 }
 

--- a/httpx/options.go
+++ b/httpx/options.go
@@ -1,0 +1,35 @@
+package httpx
+
+import (
+	"time"
+)
+
+// ServerOption is a function that configures the server
+type ServerOption func(opts *serverOptions)
+
+type serverOptions struct {
+	Host            string
+	Port            int
+	ShutdownTimeout time.Duration
+}
+
+// WithHost sets the host of the server
+func WithHost(host string) ServerOption {
+	return func(opts *serverOptions) {
+		opts.Host = host
+	}
+}
+
+// WithPort sets the port of the server
+func WithPort(port int) ServerOption {
+	return func(opts *serverOptions) {
+		opts.Port = port
+	}
+}
+
+// WithShutdownTimeout sets the shutdown timeout of the server
+func WithShutdownTimeout(timeout time.Duration) ServerOption {
+	return func(opts *serverOptions) {
+		opts.ShutdownTimeout = timeout
+	}
+}

--- a/httpx/server.go
+++ b/httpx/server.go
@@ -60,8 +60,9 @@ func (s *GinServer) Run(opts ...ServerOption) {
 
 	// Initialize http.Server based on the configured options.
 	s.httpserver = &http.Server{
-		Addr:    addr,
-		Handler: s.Router,
+		Addr:              addr,
+		Handler:           s.Router,
+		ReadHeaderTimeout: time.Second,
 	}
 
 	// Start the server asynchronously.

--- a/httpx/server.go
+++ b/httpx/server.go
@@ -1,14 +1,18 @@
 package httpx
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/blackhorseya/go-libs/logger"
 	"github.com/gin-gonic/gin"
 )
 
-// GinServer is a wrapper around the http.Server and gin.Engine
+// GinServer is a wrapper around http.Server and gin.Engine for managing routes and server lifecycle.
 type GinServer struct {
 	httpserver *http.Server
 	Router     *gin.Engine
@@ -33,4 +37,54 @@ func NewGinServer(log *slog.Logger, debug bool) *GinServer {
 		httpserver: nil,
 		Router:     router,
 	}
+}
+
+// Run starts the HTTP server asynchronously using the Options pattern.
+// Default configuration is: address ":8080", default logger, and shutdown timeout of 5 seconds.
+// Options such as WithAddr, WithLogger, and WithShutdownTimeout can be used to override the defaults.
+func (s *GinServer) Run(opts ...ServerOption) {
+	// Set default options.
+	options := &serverOptions{
+		Host:            "localhost",
+		Port:            8080,
+		Logger:          slog.Default(),
+		ShutdownTimeout: 5 * time.Second,
+	}
+	// Override defaults with provided options.
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	// Construct the address string.
+	addr := fmt.Sprintf("%s:%d", options.Host, options.Port)
+
+	// Initialize http.Server based on the configured options.
+	s.httpserver = &http.Server{
+		Addr:    addr,
+		Handler: s.Router,
+	}
+
+	// Start the server asynchronously.
+	go func() {
+		if err := s.httpserver.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			options.Logger.Error("failed to start gin server", "error", err)
+		}
+	}()
+}
+
+// Shutdown gracefully shuts down the server using the configured shutdown timeout.
+func (s *GinServer) Shutdown(opts ...ServerOption) error {
+	// Set default shutdown options.
+	options := &serverOptions{
+		ShutdownTimeout: 5 * time.Second,
+		Logger:          slog.Default(),
+	}
+	// Override defaults with provided options.
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), options.ShutdownTimeout)
+	defer cancel()
+	return s.httpserver.Shutdown(ctx)
 }

--- a/httpx/server.go
+++ b/httpx/server.go
@@ -1,0 +1,36 @@
+package httpx
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/blackhorseya/go-libs/logger"
+	"github.com/gin-gonic/gin"
+)
+
+// GinServer is a wrapper around the http.Server and gin.Engine
+type GinServer struct {
+	httpserver *http.Server
+	Router     *gin.Engine
+}
+
+// NewGinServer creates a new GinServer
+func NewGinServer(log *slog.Logger, debug bool) *GinServer {
+	middlewares := []gin.HandlerFunc{
+		logger.GinTraceLoggingMiddleware(log),
+	}
+
+	gin.SetMode(gin.ReleaseMode)
+	if debug {
+		gin.SetMode(gin.DebugMode)
+		middlewares = append(middlewares, gin.Logger())
+	}
+
+	router := gin.New()
+	router.Use(middlewares...)
+
+	return &GinServer{
+		httpserver: nil,
+		Router:     router,
+	}
+}

--- a/httpx/server.go
+++ b/httpx/server.go
@@ -74,6 +74,10 @@ func (s *GinServer) Run(opts ...ServerOption) {
 
 // Shutdown gracefully shuts down the server using the configured shutdown timeout.
 func (s *GinServer) Shutdown(opts ...ServerOption) error {
+	if s.httpserver == nil {
+		return errors.New("server is not running")
+	}
+
 	// Set default shutdown options.
 	options := &serverOptions{
 		ShutdownTimeout: 5 * time.Second,

--- a/httpx/server_test.go
+++ b/httpx/server_test.go
@@ -1,7 +1,7 @@
 package httpx
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -42,7 +42,7 @@ func TestGinServer_RunAndShutdown(t *testing.T) {
 	}
 
 	// Read and verify the response body.
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("failed to read response body: %v", err)
 	}

--- a/httpx/server_test.go
+++ b/httpx/server_test.go
@@ -1,0 +1,77 @@
+package httpx
+
+import (
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"log/slog"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestGinServer_RunAndShutdown(t *testing.T) {
+	// Create a test logger
+	logger := slog.Default()
+
+	// Create a new GinServer instance with debug mode enabled.
+	server := NewGinServer(logger, true)
+
+	// Register a test route.
+	server.Router.GET("/ping", func(c *gin.Context) {
+		c.String(http.StatusOK, "pong")
+	})
+
+	// Start the server asynchronously using default options (host "localhost", port 8080).
+	server.Run()
+
+	// Wait briefly to allow the server to start.
+	time.Sleep(100 * time.Millisecond)
+
+	// Send a GET request to the /ping endpoint.
+	resp, err := http.Get("http://localhost:8080/ping")
+	if err != nil {
+		t.Fatalf("failed to send GET request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Verify the status code is 200 OK.
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	// Read and verify the response body.
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+	if string(body) != "pong" {
+		t.Fatalf("expected response body 'pong', got '%s'", string(body))
+	}
+
+	// Shutdown the server gracefully.
+	err = server.Shutdown()
+	if err != nil {
+		t.Fatalf("failed to shutdown server: %v", err)
+	}
+}
+
+func TestGinServer_ShutdownWithoutRun(t *testing.T) {
+	// Create a test logger
+	logger := slog.Default()
+
+	// Create a new GinServer instance but do not run it.
+	server := NewGinServer(logger, true)
+
+	// Attempt to shutdown the server when it is not running.
+	err := server.Shutdown()
+	if err == nil {
+		t.Fatalf("expected error 'server is not running', got nil")
+	}
+
+	expectedErr := "server is not running"
+	if err.Error() != expectedErr {
+		t.Fatalf("expected error '%s', got %v", expectedErr, err)
+	}
+}


### PR DESCRIPTION
### **User description**
This pull request introduces a new server framework using the Gin web framework and options pattern for configuration. The changes include the addition of server options, a new GinServer type, and corresponding tests to validate the server's functionality.

### New Server Framework Implementation:

* [`httpx/options.go`](diffhunk://#diff-d5310d1aeb7a32597414336c94e0539a5f781b8e464b2da71bf45d2be7690c42R1-R45): Added `ServerOption` type and various option functions (`WithHost`, `WithPort`, `WithLogger`, `WithShutdownTimeout`) to configure server options. Defined `serverOptions` struct to hold configuration options.

* [`httpx/server.go`](diffhunk://#diff-731d80c901181d5345ef86bca12c41e5b77a011d0db928e50737fecd8248fe37R1-R95): Introduced `GinServer` type to manage HTTP server and routes. Implemented `NewGinServer` to create a new server instance, `Run` to start the server asynchronously with configurable options, and `Shutdown` to gracefully shut down the server.

### Testing:

* [`httpx/server_test.go`](diffhunk://#diff-609f2952f3305bad151d90401bcf025a0053fd76fedcbf3108f799d98f94722dR1-R77): Added tests for `GinServer` to verify server startup, route handling, and graceful shutdown. Included tests for running and shutting down the server, as well as attempting to shut down a server that is not running.


___

### **PR Type**
- Enhancement
- Tests



___

### **Description**
- Introduce configurable server option functions.

- Implement GinServer as HTTP server wrapper.

- Add tests for server startup and graceful shutdown.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>options.go</strong><dd><code>Add server configuration options.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

httpx/options.go

<li>Added ServerOption function type and serverOptions struct.<br> <li> Introduced WithHost, WithPort, WithLogger, and WithShutdownTimeout.


</details>


  </td>
  <td><a href="https://github.com/blackhorseya/go-libs/pull/7/files#diff-d5310d1aeb7a32597414336c94e0539a5f781b8e464b2da71bf45d2be7690c42">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Implement GinServer functionality.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

httpx/server.go

<li>Created GinServer struct wrapping http.Server and gin.Engine.<br> <li> Implemented NewGinServer constructor with middleware.<br> <li> Added Run method with options pattern and graceful shutdown.


</details>


  </td>
  <td><a href="https://github.com/blackhorseya/go-libs/pull/7/files#diff-731d80c901181d5345ef86bca12c41e5b77a011d0db928e50737fecd8248fe37">+95/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server_test.go</strong><dd><code>Add tests for GinServer.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

httpx/server_test.go

<li>Added tests for server startup, ping endpoint, and shutdown.<br> <li> Verified error handling when shutting down a non-running server.


</details>


  </td>
  <td><a href="https://github.com/blackhorseya/go-libs/pull/7/files#diff-609f2952f3305bad151d90401bcf025a0053fd76fedcbf3108f799d98f94722d">+77/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>